### PR TITLE
Simple check to make sure $DEVELOPER directory exists

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -35,6 +35,15 @@ CURRENTPATH=`pwd`
 ARCHS="i386 armv6 armv7"
 DEVELOPER=`xcode-select -print-path`
 
+if [ ! -d "$DEVELOPER" ]; then
+  echo "xcode path is not set correctly $DEVELOPER does not exist (most likely because of xcode 4.3)"
+  echo "run"
+  echo "sudo xcode-select -switch <xcode path>"
+  echo "for default installation:"
+  echo "sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer"
+  exit 1
+fi
+
 set -e
 if [ ! -e openssl-${VERSION}.tar.gz ]; then
 	echo "Downloading openssl-${VERSION}.tar.gz"


### PR DESCRIPTION
Encountered issue where with Xcode 4.3 the xcode-path was not pointing to the Xcode installation (default situation with 4.3 it seems), simple check to let people know that something is wrong before it gets into openssl configure and make
