### PR TITLE
Added a script to create openssl.framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ src
 build
 OpenSSL-for-iOS.xcodeproj/project.xcworkspace/xcuserdata
 include/openssl
+*.framework

--- a/create-openssl-framework.sh
+++ b/create-openssl-framework.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+FWNAME=openssl
+
+if [ ! -d lib ]; then
+    echo "Please run build-libssl.sh first!"
+    exit 1
+fi
+
+if [ -d $FWNAME.framework ]; then
+    echo "Removing previous $FWNAME.framework copy"
+    rm -rf $FWNAME.framework
+fi
+
+echo "Creating $FWNAME.framework"
+mkdir -p $FWNAME.framework/Headers
+libtool -no_warning_for_no_symbols -static -o $FWNAME.framework/$FWNAME lib/libcrypto.a lib/libssl.a
+cp -r include/$FWNAME/* $FWNAME.framework/Headers/
+echo "Created $FWNAME.framework"


### PR DESCRIPTION
I've added a script to create a framework version of openssl.

This makes it a lot easier to use as it's only one single file that needs to be added to your Xcode project instead of having to set it up manually.
