### PR TITLE
OpenSSL 1.0.2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ If you have problems building for arm64 please uninstall MacPorts (see #28).
 * <http://www.x2on.de/2010/07/13/tutorial-iphone-app-with-compiled-openssl-1-0-0a-library/>
 
 ## Changelog
+* 2015-12-05: OpenSSL 1.0.2e
 * 2015-11-17: tvOS example app, Migrate to Swift for example app
 * 2015-11-16: tvOS support
 * 2015-10-25: Xcode 7.1 support

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -21,7 +21,7 @@
 ###########################################################################
 #  Change values here													  #
 #
-VERSION="1.0.2d"													      #
+VERSION="1.0.2e"													      #
 IOS_SDKVERSION=`xcrun -sdk iphoneos --show-sdk-version`
 TVOS_SDKVERSION=`xcrun -sdk appletvos --show-sdk-version`											  #
 CONFIG_OPTIONS=""


### PR DESCRIPTION
OpenSSL version bump: 1.0.2e

Here's the Security Advisory:
https://www.openssl.org/news/secadv/20151203.txt