### PR TITLE
Update create-openssl-framework.sh

### DIFF
--- a/create-openssl-framework.sh
+++ b/create-openssl-framework.sh
@@ -22,4 +22,5 @@ echo "Creating $FWNAME.framework"
 mkdir -p $FWNAME.framework/Headers
 libtool -no_warning_for_no_symbols $LIBTOOL_FLAGS -o $FWNAME.framework/$FWNAME lib/libcrypto.a lib/libssl.a
 cp -r include/$FWNAME/* $FWNAME.framework/Headers/
+cp "OpenSSL-for-iOS/OpenSSL-for-iOS-Info.plist" $FWNAME.framework/Info.plist
 echo "Created $FWNAME.framework"


### PR DESCRIPTION
enable code sign for resultant openssl.framework , which is required for latest xCode and iOS