### PR TITLE
[03] New/travis no spinner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 osx_image: xcode7.1
 language: objective-c
 before_install: 
- - ./build-libssl.sh verbose
+ - ./build-libssl.sh --no-spinner
  - xcrun -sdk iphoneos lipo -info ./lib/*.a
  - ./create-openssl-framework.sh
  - xcrun -sdk iphoneos lipo -info openssl.framework/openssl

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -40,7 +40,7 @@ spinner()
   local pid=$!
   local delay=0.75
   local spinstr='|/-\'
-  while [ "$(ps a | awk '{print $1}' | grep $pid)" ]; do
+  while kill -0 $pid > /dev/null 2>&1; do
     local temp=${spinstr#?}
     printf " [%c]  " "$spinstr"
     local spinstr=$temp${spinstr%"$temp"}

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -240,7 +240,7 @@ do
   if [[ ! -z $CONFIG_OPTIONS ]]; then
     exec_task "make depend"
   fi
-  exec_spinner_task "make"
+  exec_spinner_task "make -j 4"
 
   echo "\n"
 

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -49,12 +49,42 @@ spinner()
   done
   printf "    \b\b\b\b"
 }
+exec_task()
+{
+  if [[ "$VERBOSE" != 0 ]]; then
+    $1
+  else
+    $1 >> "${LOG}" 2>&1
+  fi
+}
+
+exec_spinner_task()
+{
+  (exec_task "$1") & spinner
+}
 
 CURRENTPATH=`pwd`
 ARCHS="i386 x86_64 armv7 armv7s arm64 tv_x86_64 tv_arm64"
 DEVELOPER=`xcode-select -print-path`
 IOS_MIN_SDK_VERSION="7.0"
 TVOS_MIN_SDK_VERSION="9.0"
+
+VERBOSE=0
+
+while true ; do
+  if [[ $# -lt 1 ]]; then
+    break
+  fi
+  case "$1" in
+    "verbose")
+      VERBOSE=1
+      shift
+    ;;
+    *)
+      break
+    ;;
+  esac
+done
 
 if [ ! -d "$DEVELOPER" ]; then
   echo "xcode path is not set correctly $DEVELOPER does not exist"
@@ -160,19 +190,18 @@ do
 
   echo "  Configure...\c"
   set +e
-  if [ "$1" == "verbose" ]; then
-    if [ "${ARCH}" == "x86_64" ]; then
-      ./Configure no-asm darwin64-x86_64-cc --openssldir="${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk" ${LOCAL_CONFIG_OPTIONS}
-    else
-      ./Configure iphoneos-cross --openssldir="${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk" ${LOCAL_CONFIG_OPTIONS}
-    fi
+
+  args=""
+  if [ "${ARCH}" == "x86_64" ]; then
+    args="${args} no-asm darwin64-x86_64-cc"
   else
-    if [ "${ARCH}" == "x86_64" ]; then
-      (./Configure no-asm darwin64-x86_64-cc --openssldir="${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk" ${LOCAL_CONFIG_OPTIONS} > "${LOG}" 2>&1) & spinner
-    else
-      (./Configure iphoneos-cross --openssldir="${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk" ${LOCAL_CONFIG_OPTIONS} > "${LOG}" 2>&1) & spinner
-    fi
+    args="${args} iphoneos-cross"
   fi
+  args="${args} \
+    --openssldir=${CURRENTPATH}/bin/${PLATFORM}${SDKVERSION}-${ARCH}.sdk \
+    ${LOCAL_CONFIG_OPTIONS}"
+
+  exec_spinner_task "./Configure ${args}"
 
   if [ $? != 0 ]; then
     echo "Problem while configure - Please check ${LOG}"
@@ -189,17 +218,11 @@ do
 
   echo "  Make...\c"
 
-  if [ "$1" == "verbose" ]; then
-    if [[ ! -z $CONFIG_OPTIONS ]]; then
-      make depend
-    fi
-    make
-  else
-    if [[ ! -z $CONFIG_OPTIONS ]]; then
-      make depend >> "${LOG}" 2>&1
-    fi
-    (make >> "${LOG}" 2>&1) & spinner
+  if [[ ! -z $CONFIG_OPTIONS ]]; then
+    exec_task "make depend"
   fi
+  exec_spinner_task "make"
+
   echo "\n"
 
   if [ $? != 0 ]; then
@@ -208,14 +231,8 @@ do
   fi
 
   set -e
-  if [ "$1" == "verbose" ]; then
-    make install_sw
-    make clean
-  else
-    make install_sw >> "${LOG}" 2>&1
-    make clean >> "${LOG}" 2>&1
-  fi
-
+  exec_task "make install_sw"
+  exec_task "make clean"
   rm -rf "$src_work_dir"
 done
 

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -49,6 +49,16 @@ spinner()
   done
   printf "    \b\b\b\b"
 }
+dotting()
+{
+  local pid=$!
+  local delay=1.00
+  while kill -0 $pid > /dev/null 2>&1; do
+    echo ".\c"
+    sleep $delay
+  done
+}
+
 exec_task()
 {
   if [[ "$VERBOSE" != 0 ]]; then
@@ -60,7 +70,11 @@ exec_task()
 
 exec_spinner_task()
 {
-  (exec_task "$1") & spinner
+  if [[ "$SPINNER_ENABLED" != 0 ]]; then
+    (exec_task "$1") & spinner
+  else
+    (exec_task "$1") & dotting
+  fi
 }
 
 CURRENTPATH=`pwd`
@@ -70,6 +84,7 @@ IOS_MIN_SDK_VERSION="7.0"
 TVOS_MIN_SDK_VERSION="9.0"
 
 VERBOSE=0
+SPINNER_ENABLED=1
 
 while true ; do
   if [[ $# -lt 1 ]]; then
@@ -78,6 +93,10 @@ while true ; do
   case "$1" in
     "verbose")
       VERBOSE=1
+      shift
+    ;;
+    "--no-spinner")
+      SPINNER_ENABLED=0
       shift
     ;;
     *)


### PR DESCRIPTION
On Travis CI, `ps` command does not work correctly so build fails.
This replace `ps` to `kill -0`to avoid it.

Its not enough because Travis console does not react `\b` character.
So output shows that likes `[/] [|] [\] [-]...`

But in verbose mode, output log is too long to Travis CI.
It can run standalone, but It can not run as sub-build within other build task.

Finally I implement `no spinner` mode.
In this mode, dot character is printed by every seconds.
Its good for Travis CI.

To keep code simply with modification above,
I write `exec_task()` and `exec_spinner_task()` and reduce redundant code.

I organized and split some commits to review easy.
Please check them.

