### PR TITLE
Fix changelog date for OpenSSL 1.0.2h support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you have problems building for arm64 please uninstall MacPorts (see [#28](htt
 * <http://www.x2on.de/2010/07/13/tutorial-iphone-app-with-compiled-openssl-1-0-0a-library/>
 
 ## Changelog
-* 2015-05-04: OpenSSL 1.0.2h
+* 2016-05-04: OpenSSL 1.0.2h
 * 2015-12-11: Xcode 7.2 support, iOS 9.2
 * 2015-12-03: OpenSSL 1.0.2e
 * 2015-11-17: tvOS example app, Migrate to Swift for example app


### PR DESCRIPTION
Changelog date for OpenSSL 1.0.2h support said 2015 instead of 2016.