### PR TITLE
Fix error handling for non-verbose mode, add verbose-on-error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 osx_image: xcode7.3
 language: objective-c
 before_install:
- - ./build-libssl.sh verbose
+ - ./build-libssl.sh verbose-on-error
  - xcrun -sdk iphoneos lipo -info ./lib/*.a
  - ./create-openssl-framework.sh
  - xcrun -sdk iphoneos lipo -info openssl.framework/openssl


### PR DESCRIPTION
- Error handling was broken since spinner() did not return the status of the command that was executed
- New option verbose-on-error to limit output, but still log in case of errors (for Travis builds - 1.1.0 build ran into the Travis log size limit, which will abort the build)
- Check for errors during make depend
- Also log to file for verbose builds
- Remove make clean since the full build directory is removed anyway
- Make spinner cursor less nervous