### PR TITLE
Specify build configuration with command line parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 osx_image: xcode8
 language: objective-c
 before_install:
- - ./build-libssl.sh verbose-on-error
+ - ./build-libssl.sh --noparallel --verbose-on-error
  - xcrun -sdk iphoneos lipo -info ./lib/*.a
  - ./create-openssl-framework.sh
  - xcrun -sdk iphoneos lipo -info openssl.framework/openssl


### PR DESCRIPTION
- Added help message
- Command line arguments processing
- Retrieve latest version from 1.0.2 branch in case no version is specified
- Use script location as working dir
- Add summary of build options
- Clean up directories before build

Also updated Travis config to run make with single job.

When no version number is provided, the script will now automatically build the latest version in the 1.0.2 branch.