### PR TITLE
issues/126: fix opensslconf.h not compatible with all builds

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #  Automatic build script for libssl and libcrypto
 #  for iPhoneOS and iPhoneSimulator
@@ -78,7 +78,7 @@ check_status()
   local STATUS=$1
   local COMMAND=$2
 
-  echo "\n"
+  echo -e "\n"
   if [ "${STATUS}" != 0 ]; then
     if [[ "${LOG_VERBOSE}" != "verbose"* ]]; then
       echo "Problem during ${COMMAND} - Please check ${LOG}"
@@ -405,7 +405,7 @@ do
   fi
 
   # Run Configure
-  echo "  Configure...\c"
+  echo -e "  Configure...\c"
   set +e
   if [ "${LOG_VERBOSE}" == "verbose" ]; then
     ./Configure ${LOCAL_CONFIG_OPTIONS} | tee "${LOG}"
@@ -424,7 +424,7 @@ do
 
   # Run make depend if relevant
   if [[ ! -z "${CONFIG_OPTIONS}" ]]; then
-    echo "  Make depend...\c"
+    echo -e "  Make depend...\c"
     if [ "${LOG_VERBOSE}" == "verbose" ]; then
       make depend | tee -a "${LOG}"
     else
@@ -436,7 +436,7 @@ do
   fi
 
   # Run make
-  echo "  Make...\c"
+  echo -e "  Make...\c"
   if [ "${LOG_VERBOSE}" == "verbose" ]; then
     make -j "${BUILD_THREADS}" | tee -a "${LOG}"
   else
@@ -471,17 +471,13 @@ do
     INCLUDE_DIR="${TARGETDIR}/include/openssl"
   else
     # make sure the just-compiled version has a compatible opensslconf.h
-    TEMP1=`mktemp`
-    TEMP2=`mktemp`
-    grep -v 'ENGINESDIR\|OPENSSLDIR\|SYSNAME\|SIXTY_FOUR_BIT_LONG\|THIRTY_TWO_BIT\|BN_LLONG' ${INCLUDE_DIR}/opensslconf.h > $TEMP1
-    grep -v 'ENGINESDIR\|OPENSSLDIR\|SYSNAME\|SIXTY_FOUR_BIT_LONG\|THIRTY_TWO_BIT\|BN_LLONG' ${TARGETDIR}/include/openssl/opensslconf.h > $TEMP2
-    if ! cmp $TEMP1 $TEMP2 > /dev/null ; then
+    EXISTING=$(grep -v 'ENGINESDIR\|OPENSSLDIR\|SYSNAME\|SIXTY_FOUR_BIT_LONG\|THIRTY_TWO_BIT\|BN_LLONG' ${INCLUDE_DIR}/opensslconf.h)
+    THIS_BUILD=$(grep -v 'ENGINESDIR\|OPENSSLDIR\|SYSNAME\|SIXTY_FOUR_BIT_LONG\|THIRTY_TWO_BIT\|BN_LLONG' ${TARGETDIR}/include/openssl/opensslconf.h)
+    if [ "$EXISTING" != "$THIS_BUILD" ] ; then
       echo "opensslconf.h is different between platforms! this is bad!"
-      diff -uN $TEMP1 $TEMP2;
-      rm $TEMP1 $TEMP2;
+      diff -uN <(echo "$EXISTING") <(echo "$THIS_BUILD")
       exit 1;
     fi
-    rm $TEMP1 $TEMP2;
   fi
 done
 

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -384,7 +384,15 @@ do
     LC_ALL=C sed -i -- 's/D\_REENTRANT\:iOS/D\_REENTRANT\:tvOS/' "./Configure"
   else
     LOCAL_CONFIG_OPTIONS="${LOCAL_CONFIG_OPTIONS} -miphoneos-version-min=${IOS_MIN_SDK_VERSION}"
-    fi
+  fi
+
+  if [ "${ARCH}" == "x86_64" ] ; then
+    # make sure DES_LONG is set to unsigned long, also for the darwin64-x86_64 build, as otherwise opensslconf.h
+    # will have a different value (unsigned int) for x86_64, whereas every iphoneos-cross build has unsigned long.
+    # this would lead to various stack corruptions when using DES methods on devices.
+    # enable RC4_CHAR, BN_LLONG and BF_PTR for the same reason
+    LC_ALL=C sed -ie 's/^"darwin64-x86_64-cc"\(.*\)DES_INT\(.*\)/"darwin64-x86_64-cc"\1RC4_CHAR BN_LLONG BF_PTR\2/' "./Configure"
+  fi
 
   # Add --openssldir option
   LOCAL_CONFIG_OPTIONS="--openssldir=${TARGETDIR} ${LOCAL_CONFIG_OPTIONS}"
@@ -393,7 +401,7 @@ do
   if [ "${ARCH}" == "x86_64" ]; then
     LOCAL_CONFIG_OPTIONS="darwin64-x86_64-cc no-asm ${LOCAL_CONFIG_OPTIONS}"
   else
-    LOCAL_CONFIG_OPTIONS="iphoneos-cross ${LOCAL_CONFIG_OPTIONS}"
+    LOCAL_CONFIG_OPTIONS="iphoneos-cross no-asm ${LOCAL_CONFIG_OPTIONS}"
   fi
 
   # Run Configure
@@ -461,6 +469,19 @@ do
   # Keep reference to first build target for include file
   if [ -z "${INCLUDE_DIR}" ]; then
     INCLUDE_DIR="${TARGETDIR}/include/openssl"
+  else
+    # make sure the just-compiled version has a compatible opensslconf.h
+    TEMP1=`mktemp`
+    TEMP2=`mktemp`
+    grep -v 'ENGINESDIR\|OPENSSLDIR\|SYSNAME\|SIXTY_FOUR_BIT_LONG\|THIRTY_TWO_BIT' ${INCLUDE_DIR}/opensslconf.h > $TEMP1
+    grep -v 'ENGINESDIR\|OPENSSLDIR\|SYSNAME\|SIXTY_FOUR_BIT_LONG\|THIRTY_TWO_BIT' ${TARGETDIR}/include/openssl/opensslconf.h > $TEMP2
+    if ! cmp $TEMP1 $TEMP2 > /dev/null ; then
+      echo "opensslconf.h is different between platforms! this is bad!"
+      diff -uN $TEMP1 $TEMP2;
+      rm $TEMP1 $TEMP2;
+      exit 1;
+    fi
+    rm $TEMP1 $TEMP2;
   fi
 done
 

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -390,8 +390,8 @@ do
     # make sure DES_LONG is set to unsigned long, also for the darwin64-x86_64 build, as otherwise opensslconf.h
     # will have a different value (unsigned int) for x86_64, whereas every iphoneos-cross build has unsigned long.
     # this would lead to various stack corruptions when using DES methods on devices.
-    # enable RC4_CHAR, BN_LLONG and BF_PTR for the same reason
-    LC_ALL=C sed -ie 's/^"darwin64-x86_64-cc"\(.*\)DES_INT\(.*\)/"darwin64-x86_64-cc"\1RC4_CHAR BN_LLONG BF_PTR\2/' "./Configure"
+    # enable RC4_CHAR and BF_PTR for the same reason
+    LC_ALL=C sed -ie 's/^"darwin64-x86_64-cc"\(.*\)DES_INT\(.*\)/"darwin64-x86_64-cc"\1RC4_CHAR BF_PTR\2/' "./Configure"
   fi
 
   # Add --openssldir option
@@ -473,8 +473,8 @@ do
     # make sure the just-compiled version has a compatible opensslconf.h
     TEMP1=`mktemp`
     TEMP2=`mktemp`
-    grep -v 'ENGINESDIR\|OPENSSLDIR\|SYSNAME\|SIXTY_FOUR_BIT_LONG\|THIRTY_TWO_BIT' ${INCLUDE_DIR}/opensslconf.h > $TEMP1
-    grep -v 'ENGINESDIR\|OPENSSLDIR\|SYSNAME\|SIXTY_FOUR_BIT_LONG\|THIRTY_TWO_BIT' ${TARGETDIR}/include/openssl/opensslconf.h > $TEMP2
+    grep -v 'ENGINESDIR\|OPENSSLDIR\|SYSNAME\|SIXTY_FOUR_BIT_LONG\|THIRTY_TWO_BIT\|BN_LLONG' ${INCLUDE_DIR}/opensslconf.h > $TEMP1
+    grep -v 'ENGINESDIR\|OPENSSLDIR\|SYSNAME\|SIXTY_FOUR_BIT_LONG\|THIRTY_TWO_BIT\|BN_LLONG' ${TARGETDIR}/include/openssl/opensslconf.h > $TEMP2
     if ! cmp $TEMP1 $TEMP2 > /dev/null ; then
       echo "opensslconf.h is different between platforms! this is bad!"
       diff -uN $TEMP1 $TEMP2;


### PR DESCRIPTION
- see https://github.com/x2on/OpenSSL-for-iPhone/issues/126
- make sure opensslconf.h is compatible in the future
