### PR TITLE
Update default 1.1.0 build to OpenSSL 1.1.0c

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenSSL-for-iOS [![Build Status](https://travis-ci.org/x2on/OpenSSL-for-iPhone.svg)](https://travis-ci.org/x2on/OpenSSL-for-iPhone) [![license](https://img.shields.io/github/license/x2on/OpenSSL-for-iPhone.svg)](https://github.com/x2on/OpenSSL-for-iPhone/blob/master/LICENSE) [![OpenSSL version](https://img.shields.io/badge/OpenSSL-1.0.2j-lightgrey.svg)]() [![OpenSSL version](https://img.shields.io/badge/OpenSSL-1.1.0b-lightgrey.svg)]() [![iOS support](https://img.shields.io/badge/iOS-7.0%20--%2010.0-lightgrey.svg)]() [![tvOS support](https://img.shields.io/badge/tvOS-9.2--%2010.0-lightgrey.svg)]()
+# OpenSSL-for-iOS [![Build Status](https://travis-ci.org/x2on/OpenSSL-for-iPhone.svg)](https://travis-ci.org/x2on/OpenSSL-for-iPhone) [![license](https://img.shields.io/github/license/x2on/OpenSSL-for-iPhone.svg)](https://github.com/x2on/OpenSSL-for-iPhone/blob/master/LICENSE) [![OpenSSL version](https://img.shields.io/badge/OpenSSL-1.0.2j-lightgrey.svg)]() [![OpenSSL version](https://img.shields.io/badge/OpenSSL-1.1.0c-lightgrey.svg)]() [![iOS support](https://img.shields.io/badge/iOS-7.0%20--%2010.0-lightgrey.svg)]() [![tvOS support](https://img.shields.io/badge/tvOS-9.2--%2010.0-lightgrey.svg)]()
 
 This is a script for using self-compiled builds of the OpenSSL-library on the iPhone. You can build apps with Xcode and the official SDK from Apple with this. I also made a small example-app for using the libraries with Xcode and the iPhone/iPhone-Simulator.
 
@@ -9,9 +9,9 @@ You must build the OpenSSL-Libraries (1.0.2j) before running the sample with:
 ./build-libssl.sh
 ```
 
-To build OpenSSL 1.1.0b build the OpenSSL-Libraries with:
+To build OpenSSL 1.1.0c build the OpenSSL-Libraries with:
 ```bash
-./build-libssl.sh --branch=1.1.0
+./build-libssl.sh --version=1.1.0c
 ```
 
 For all options see the help
@@ -33,6 +33,7 @@ If you have problems building for arm64 please uninstall MacPorts (see [#28](htt
 * <http://www.x2on.de/2010/07/13/tutorial-iphone-app-with-compiled-openssl-1-0-0a-library/>
 
 ## Changelog
+* 2016-11-13: OpenSSL 1.1.0c
 * 2016-11-07: Optional support for OpenSSL 1.1.0b
 * 2016-09-28: OpenSSL 1.0.2j
 * 2016-09-22: OpenSSL 1.0.2i

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -19,7 +19,7 @@ PID_ARCHS=$!
 mkdir targets
 cd targets
 cp -r ../include .
-../build-libssl.sh --noparallel --verbose-on-error --ec-nistp-64-gcc-128 --version=1.1.0b | log_output "TARGETS" &
+../build-libssl.sh --noparallel --verbose-on-error --ec-nistp-64-gcc-128 --version=1.1.0c | log_output "TARGETS" &
 PID_TARGETS=$!
 
 echo "SCRIPT  Started jobs, waiting for jobs to finish"


### PR DESCRIPTION
OpenSSL released version 1.1.0c. This will update the Travis build to 1.1.0c. Also, I changed the documented option to build 1.1.0 with the fixed version number. (--branch builds the most recent version).