### PR TITLE
Download from openssl.org

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -267,14 +267,14 @@ elif [ -n "${BRANCH}" ]; then
 
   # Valid version number, determine latest version
   else
-    echo "Checking latest version of ${BRANCH} branch on ftp.openssl.org..."
-    # Get directory content of /source/ (only contains latest version per branch), limit list to archives (so one archive per branch),
+    echo "Checking latest version of ${BRANCH} branch on openssl.org..."
+    # Get directory content listing of /source/ (only contains latest version per branch), limit list to archives (so one archive per branch),
     # filter for the requested branch, sort the list and get the last item (last two steps to ensure there is always 1 result)
-    VERSION=$(curl ${CURL_OPTIONS} -ls ftp://ftp.openssl.org/source/ | grep -Eo '^openssl-[0-9]\.[0-9]\.[0-9][a-z]*\.tar\.gz$' | grep -Eo "${BRANCH//./\.}[a-z]*" | sort | tail -1)
+    VERSION=$(curl ${CURL_OPTIONS} -s https://ftp.openssl.org/source/ | grep -Eo '>openssl-[0-9]\.[0-9]\.[0-9][a-z]*\.tar\.gz<' | grep -Eo "${BRANCH//./\.}[a-z]*" | sort | tail -1)
 
     # Verify result
     if [ -z "${VERSION}" ]; then
-      echo "Could not determine latest version, please check https://openssl.org/source/ and use --version option"
+      echo "Could not determine latest version, please check https://www.openssl.org/source/ and use --version option"
       exit 1
     fi
   fi

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -384,30 +384,30 @@ OPENSSL_ARCHIVE_BASE_NAME="openssl-${VERSION}"
 OPENSSL_ARCHIVE_FILE_NAME="${OPENSSL_ARCHIVE_BASE_NAME}.tar.gz"
 if [ ! -e ${OPENSSL_ARCHIVE_FILE_NAME} ]; then
   echo "Downloading ${OPENSSL_ARCHIVE_FILE_NAME}..."
-  OPENSSL_ARCHIVE_URL="ftp://ftp.openssl.org/source/${OPENSSL_ARCHIVE_FILE_NAME}"
+  OPENSSL_ARCHIVE_URL="source/${OPENSSL_ARCHIVE_FILE_NAME}"
 
   # Check whether file exists here
   # -s be silent, -f return non-zero exit status on failure, -I get header (do not download)
-  curl ${CURL_OPTIONS} -sfI "${OPENSSL_ARCHIVE_URL}" > /dev/null
+  curl ${CURL_OPTIONS} -sfI "ftp://ftp.openssl.org/${OPENSSL_ARCHIVE_URL}" > /dev/null
 
   # If unsuccessful, try the archive
   if [ $? -ne 0 ]; then
     BRANCH=$(echo "${VERSION}" | grep -Eo '^[0-9]\.[0-9]\.[0-9]')
-    OPENSSL_ARCHIVE_URL="ftp://ftp.openssl.org/source/old/${BRANCH}/${OPENSSL_ARCHIVE_FILE_NAME}"
+    OPENSSL_ARCHIVE_URL="source/old/${BRANCH}/${OPENSSL_ARCHIVE_FILE_NAME}"
 
-    curl ${CURL_OPTIONS} -sfI "${OPENSSL_ARCHIVE_URL}" > /dev/null
+    curl ${CURL_OPTIONS} -sfI "ftp://ftp.openssl.org/${OPENSSL_ARCHIVE_URL}" > /dev/null
   fi
 
   # Both attempts failed, so report the error
   if [ $? -ne 0 ]; then
-    echo "An error occured when trying to download OpenSSL ${VERSION} from ${OPENSSL_ARCHIVE_URL}."
+    echo "An error occurred trying to find OpenSSL ${VERSION} on ftp://ftp.openssl.org/${OPENSSL_ARCHIVE_URL}"
     echo "Please verify that the version you are trying to build exists, check cURL's error message and/or your network connection."
     exit 1
   fi
 
-  # Archive was found, so proceed with download
+  # Archive was found, so proceed with download. Download over https
   # -O Use server-specified filename for download
-  curl ${CURL_OPTIONS} -O "${OPENSSL_ARCHIVE_URL}"
+  curl ${CURL_OPTIONS} -O "https://www.openssl.org/${OPENSSL_ARCHIVE_URL}"
 
 else
   echo "Using ${OPENSSL_ARCHIVE_FILE_NAME}"

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -474,3 +474,4 @@ fi
 cp -R "${INCLUDE_DIR}" ${CURRENTPATH}/include/
 
 echo "Done."
+

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -384,30 +384,30 @@ OPENSSL_ARCHIVE_BASE_NAME="openssl-${VERSION}"
 OPENSSL_ARCHIVE_FILE_NAME="${OPENSSL_ARCHIVE_BASE_NAME}.tar.gz"
 if [ ! -e ${OPENSSL_ARCHIVE_FILE_NAME} ]; then
   echo "Downloading ${OPENSSL_ARCHIVE_FILE_NAME}..."
-  OPENSSL_ARCHIVE_URL="source/${OPENSSL_ARCHIVE_FILE_NAME}"
+  OPENSSL_ARCHIVE_URL="https://www.openssl.org/source/${OPENSSL_ARCHIVE_FILE_NAME}"
 
-  # Check whether file exists here
+  # Check whether file exists here (this is the location of the latest version for each branch)
   # -s be silent, -f return non-zero exit status on failure, -I get header (do not download)
-  curl ${CURL_OPTIONS} -sfI "ftp://ftp.openssl.org/${OPENSSL_ARCHIVE_URL}" > /dev/null
+  curl ${CURL_OPTIONS} -sfI "${OPENSSL_ARCHIVE_URL}" > /dev/null
 
   # If unsuccessful, try the archive
   if [ $? -ne 0 ]; then
     BRANCH=$(echo "${VERSION}" | grep -Eo '^[0-9]\.[0-9]\.[0-9]')
-    OPENSSL_ARCHIVE_URL="source/old/${BRANCH}/${OPENSSL_ARCHIVE_FILE_NAME}"
+    OPENSSL_ARCHIVE_URL="https://www.openssl.org/source/old/${BRANCH}/${OPENSSL_ARCHIVE_FILE_NAME}"
 
-    curl ${CURL_OPTIONS} -sfI "ftp://ftp.openssl.org/${OPENSSL_ARCHIVE_URL}" > /dev/null
+    curl ${CURL_OPTIONS} -sfI "${OPENSSL_ARCHIVE_URL}" > /dev/null
   fi
 
   # Both attempts failed, so report the error
   if [ $? -ne 0 ]; then
-    echo "An error occurred trying to find OpenSSL ${VERSION} on ftp://ftp.openssl.org/${OPENSSL_ARCHIVE_URL}"
+    echo "An error occurred trying to find OpenSSL ${VERSION} on ${OPENSSL_ARCHIVE_URL}"
     echo "Please verify that the version you are trying to build exists, check cURL's error message and/or your network connection."
     exit 1
   fi
 
-  # Archive was found, so proceed with download. Download over https
+  # Archive was found, so proceed with download.
   # -O Use server-specified filename for download
-  curl ${CURL_OPTIONS} -O "https://www.openssl.org/${OPENSSL_ARCHIVE_URL}"
+  curl ${CURL_OPTIONS} -O "${OPENSSL_ARCHIVE_URL}"
 
 else
   echo "Using ${OPENSSL_ARCHIVE_FILE_NAME}"


### PR DESCRIPTION
Based on [this comment](https://github.com/openssl/openssl/issues/1703#issuecomment-253367927) on OpenSSL's Github page, I didn't like the fact that the script downloads from Github. So I made an update to download directly from openssl.org. I use FTP to easily determine the latest version and download the archive over HTTPS.