### PR TITLE
openssl 1.1.x's default configuration results in app store rejection

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -60,7 +60,6 @@ echo_help()
   echo "                                     Note: The framework will contain include files from the architecture listed first"
   echo
   echo "Options for OpenSSL 1.1.0 and higher ONLY"
-  echo "     --async                       Exclude no-async configure option and build with async support - do not use if submitting to App Store"
   echo "     --deprecated                  Exclude no-deprecated configure option and build with deprecated methods"
   echo "     --targets=\"TARGET TARGET ...\" Space-separated list of build targets"
   echo "                                     Options: ${DEFAULTTARGETS}"
@@ -185,7 +184,6 @@ ARCHS=""
 BRANCH=""
 CLEANUP=""
 CONFIG_ENABLE_EC_NISTP_64_GCC_128=""
-CONFIG_NO_ASYNC=""
 CONFIG_NO_DEPRECATED=""
 IOS_SDKVERSION=""
 LOG_VERBOSE=""
@@ -201,9 +199,6 @@ case $i in
   --archs=*)
     ARCHS="${i#*=}"
     shift
-    ;;
-  --async)
-    CONFIG_NO_ASYNC="false"
     ;;
   --branch=*)
     BRANCH="${i#*=}"
@@ -313,11 +308,6 @@ else
   # Set default for TARGETS if not specified
   if [ ! -n "${TARGETS}" ]; then
     TARGETS="${DEFAULTTARGETS}"
-  fi
-
-  # Add no-async config option (if not overwritten) - async being enabled leads to App Store rejection
-  if [ "${CONFIG_NO_ASYNC}" != "false" ]; then
-    CONFIG_OPTIONS="${CONFIG_OPTIONS} no-async"
   fi
 
   # Add no-deprecated config option (if not overwritten)

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -60,6 +60,7 @@ echo_help()
   echo "                                     Note: The framework will contain include files from the architecture listed first"
   echo
   echo "Options for OpenSSL 1.1.0 and higher ONLY"
+  echo "     --async                       Exclude no-async configure option and build with async support - do not use if submitting to App Store"
   echo "     --deprecated                  Exclude no-deprecated configure option and build with deprecated methods"
   echo "     --targets=\"TARGET TARGET ...\" Space-separated list of build targets"
   echo "                                     Options: ${DEFAULTTARGETS}"
@@ -184,6 +185,7 @@ ARCHS=""
 BRANCH=""
 CLEANUP=""
 CONFIG_ENABLE_EC_NISTP_64_GCC_128=""
+CONFIG_NO_ASYNC=""
 CONFIG_NO_DEPRECATED=""
 IOS_SDKVERSION=""
 LOG_VERBOSE=""
@@ -199,6 +201,9 @@ case $i in
   --archs=*)
     ARCHS="${i#*=}"
     shift
+    ;;
+  --async)
+    CONFIG_NO_ASYNC="false"
     ;;
   --branch=*)
     BRANCH="${i#*=}"
@@ -308,6 +313,11 @@ else
   # Set default for TARGETS if not specified
   if [ ! -n "${TARGETS}" ]; then
     TARGETS="${DEFAULTTARGETS}"
+  fi
+
+  # Add no-async config option (if not overwritten) - async being enabled leads to App Store rejection
+  if [ "${CONFIG_NO_ASYNC}" != "false" ]; then
+    CONFIG_OPTIONS="${CONFIG_OPTIONS} no-async"
   fi
 
   # Add no-deprecated config option (if not overwritten)

--- a/scripts/build-loop-targets.sh
+++ b/scripts/build-loop-targets.sh
@@ -56,8 +56,10 @@ do
   prepare_target_source_dirs
 
   ## Determine config options
-  # Add build target, --prefix and prevent creation of shared libraries (default since 1.1.0)
-  LOCAL_CONFIG_OPTIONS="${TARGET} --prefix=${TARGETDIR} ${CONFIG_OPTIONS} no-shared"
+  # Add build target, --prefix and prevent async (references to getcontext(),
+  # setcontext() and makecontext() result in App Store rejections) and creation
+  # of shared libraries (default since 1.1.0)
+  LOCAL_CONFIG_OPTIONS="${TARGET} --prefix=${TARGETDIR} ${CONFIG_OPTIONS} no-async no-shared"
 
   # Only relevant for 64 bit builds
   if [[ "${CONFIG_ENABLE_EC_NISTP_64_GCC_128}" == "true" && "${ARCH}" == *64  ]]; then

--- a/scripts/build-loop-targets.sh
+++ b/scripts/build-loop-targets.sh
@@ -64,11 +64,6 @@ do
     LOCAL_CONFIG_OPTIONS="${LOCAL_CONFIG_OPTIONS} enable-ec_nistp_64_gcc_128"
   fi
 
-  # Disable unavailable async for tvOS builds
-  if [[ "${PLATFORM}" == AppleTV* ]]; then
-    LOCAL_CONFIG_OPTIONS="${LOCAL_CONFIG_OPTIONS} no-async"
-  fi
-
   # Run Configure
   run_configure
 


### PR DESCRIPTION
OpenSSL's async configuration option, which is enabled by default, falls foul of the App Store's vetting processes. Apps including OpenSSL 1.1.0 and higher are rejected with the following message from Apple:

> We have discovered one or more issues with your recent delivery for "<app name>". To process your delivery, the following issues must be corrected:
> 
> Non-public API usage:
> 
> The app references non-public symbols in <app name>: _getcontext, _makecontext, _setcontext

This PR fixes this by configuring 1.1.0 and higher with no-async by default.

P.S. Thanks for this maintaining this project: it's been a great help.