### PR TITLE
Allow disabling embedded Bitcode

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -50,6 +50,7 @@ echo_help()
   echo "     --ios-sdk=SDKVERSION          Override iOS SDK version"
   echo "     --noparallel                  Disable running make with parallel jobs (make -j)"
   echo "     --tvos-sdk=SDKVERSION         Override tvOS SDK version"
+  echo "     --disable-bitcode             Disable embedding Bitcode"
   echo " -v, --verbose                     Enable verbose logging"
   echo "     --verbose-on-error            Dump last 500 lines from log file if an error occurs (for Travis builds)"
   echo "     --version=VERSION             OpenSSL version to build (defaults to ${DEFAULTVERSION})"
@@ -57,7 +58,6 @@ echo_help()
   echo "Options for OpenSSL 1.0.2 and lower ONLY"
   echo "     --archs=\"ARCH ARCH ...\"       Space-separated list of architectures to build"
   echo "                                     Options: ${DEFAULTARCHS}"
-  echo "     --disable-bitcode             Disable embedding Bitcode"
   echo
   echo "Options for OpenSSL 1.1.0 and higher ONLY"
   echo "     --deprecated                  Exclude no-deprecated configure option and build with deprecated methods"
@@ -377,16 +377,14 @@ echo "Build options"
 echo "  OpenSSL version: ${VERSION}"
 if [ "${BUILD_TYPE}" == "archs" ]; then
   echo "  Architectures: ${ARCHS}"
-  if [ "${CONFIG_DISABLE_BITCODE}" == "true" ]; then
-    echo "  Bitcode disabled"
-  else
-    echo "  Bitcode enabled"
-  fi
 else
   echo "  Targets: ${TARGETS}"
 fi
 echo "  iOS SDK: ${IOS_SDKVERSION}"
 echo "  tvOS SDK: ${TVOS_SDKVERSION}"
+if [ "${CONFIG_DISABLE_BITCODE}" == "true" ]; then
+  echo "  Bitcode embedding disabled"
+fi
 echo "  Number of make threads: ${BUILD_THREADS}"
 if [ -n "${CONFIG_OPTIONS}" ]; then
   echo "  Configure options: ${CONFIG_OPTIONS}"

--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -57,6 +57,7 @@ echo_help()
   echo "Options for OpenSSL 1.0.2 and lower ONLY"
   echo "     --archs=\"ARCH ARCH ...\"       Space-separated list of architectures to build"
   echo "                                     Options: ${DEFAULTARCHS}"
+  echo "     --disable-bitcode             Disable embedding Bitcode"
   echo
   echo "Options for OpenSSL 1.1.0 and higher ONLY"
   echo "     --deprecated                  Exclude no-deprecated configure option and build with deprecated methods"
@@ -189,6 +190,7 @@ ARCHS=""
 BRANCH=""
 CLEANUP=""
 CONFIG_ENABLE_EC_NISTP_64_GCC_128=""
+CONFIG_DISABLE_BITCODE=""
 CONFIG_NO_DEPRECATED=""
 IOS_SDKVERSION=""
 LOG_VERBOSE=""
@@ -217,6 +219,9 @@ case $i in
     ;;
   --ec-nistp-64-gcc-128)
     CONFIG_ENABLE_EC_NISTP_64_GCC_128="true"
+    ;;
+  --disable-bitcode)
+    CONFIG_DISABLE_BITCODE="true"
     ;;
   -h|--help)
     echo_help
@@ -372,6 +377,11 @@ echo "Build options"
 echo "  OpenSSL version: ${VERSION}"
 if [ "${BUILD_TYPE}" == "archs" ]; then
   echo "  Architectures: ${ARCHS}"
+  if [ "${CONFIG_DISABLE_BITCODE}" == "true" ]; then
+    echo "  Bitcode disabled"
+  else
+    echo "  Bitcode enabled"
+  fi
 else
   echo "  Targets: ${TARGETS}"
 fi

--- a/config/20-ios-tvos-cross.conf
+++ b/config/20-ios-tvos-cross.conf
@@ -9,7 +9,7 @@
     "ios-tvos-cross-base" => {
         template         => 1,
         cflags           => combine('-isysroot $(CROSS_TOP)/SDKs/$(CROSS_SDK) -fno-common',
-                				sub { ((!defined($ENV{'CONFIG_DISABLE_BITCODE'}) || $ENV{'CONFIG_DISABLE_BITCODE'} !~ /true/) && defined($ENV{'SDKVERSION'}) && $ENV{'SDKVERSION'} =~ /^(9|[1-9][0-9]+)\./ && $disabled{shared})
+                				sub { ((!defined($ENV{'CONFIG_DISABLE_BITCODE'}) || $ENV{'CONFIG_DISABLE_BITCODE'} ne 'true') && defined($ENV{'SDKVERSION'}) && $ENV{'SDKVERSION'} =~ /^(9|[1-9][0-9]+)\./ && $disabled{shared})
                 						? '-fembed-bitcode' : (); },
         					),
     },

--- a/config/20-ios-tvos-cross.conf
+++ b/config/20-ios-tvos-cross.conf
@@ -9,7 +9,7 @@
     "ios-tvos-cross-base" => {
         template         => 1,
         cflags           => combine('-isysroot $(CROSS_TOP)/SDKs/$(CROSS_SDK) -fno-common',
-                				sub { (defined($ENV{'SDKVERSION'}) && $ENV{'SDKVERSION'} =~ /^(9|[1-9][0-9]+)\./ && $disabled{shared})
+                				sub { ((!defined($ENV{'CONFIG_DISABLE_BITCODE'}) || $ENV{'CONFIG_DISABLE_BITCODE'} !~ /true/) && defined($ENV{'SDKVERSION'}) && $ENV{'SDKVERSION'} =~ /^(9|[1-9][0-9]+)\./ && $disabled{shared})
                 						? '-fembed-bitcode' : (); },
         					),
     },

--- a/scripts/build-loop-archs.sh
+++ b/scripts/build-loop-archs.sh
@@ -61,8 +61,10 @@ do
   fi
 
   # Embed bitcode for SDK >= 9
-  if [[ "${SDKVERSION}" == 9.* || "${SDKVERSION}" == [0-9][0-9].* ]]; then
-    LOCAL_CONFIG_OPTIONS="${LOCAL_CONFIG_OPTIONS} -fembed-bitcode"
+  if [ "${CONFIG_DISABLE_BITCODE}" != "true" ]; then
+    if [[ "${SDKVERSION}" == 9.* || "${SDKVERSION}" == [0-9][0-9].* ]]; then
+      LOCAL_CONFIG_OPTIONS="${LOCAL_CONFIG_OPTIONS} -fembed-bitcode"
+    fi
   fi
 
   # Add platform specific config options

--- a/scripts/build-loop-targets.sh
+++ b/scripts/build-loop-targets.sh
@@ -32,6 +32,7 @@ do
   export SDKVERSION
   export IOS_MIN_SDK_VERSION
   export TVOS_MIN_SDK_VERSION
+  export CONFIG_DISABLE_BITCODE
 
   # Determine platform
   if [[ "${TARGET}" == "ios-sim-cross-"* ]]; then


### PR DESCRIPTION
Just an option added to allow shrinking the fat lib size if no bitcode needed (in my case ~37MB --> 13.4MB).
Notice: I care only with version 1.0.2 and lower

Thank you,
bithug