### PR TITLE
[2019.03.11] support arm64e architecture & disable multithread build …

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -25,15 +25,15 @@ set -u
 # SCRIPT DEFAULTS
 
 # Default version in case no version is specified
-DEFAULTVERSION="1.0.2l"
+DEFAULTVERSION="1.1.0h"
 
 # Default (=full) set of architectures (OpenSSL <= 1.0.2) or targets (OpenSSL >= 1.1.0) to build
-DEFAULTARCHS="x86_64 i386 arm64 armv7s armv7 tv_x86_64 tv_arm64"
-DEFAULTTARGETS="ios-sim-cross-x86_64 ios-sim-cross-i386 ios64-cross-arm64 ios-cross-armv7s ios-cross-armv7 tvos-sim-cross-x86_64 tvos64-cross-arm64"
+DEFAULTARCHS="x86_64 arm64 arm64e armv7s armv7 tv_x86_64 tv_arm64"
+DEFAULTTARGETS="ios-sim-cross-x86_64 ios64-cross-arm64 ios64-cross-arm64e ios-cross-armv7s ios-cross-armv7 tvos-sim-cross-x86_64 tvos64-cross-arm64"
 
 # Minimum iOS/tvOS SDK version to build for
-IOS_MIN_SDK_VERSION="7.0"
-TVOS_MIN_SDK_VERSION="9.0"
+IOS_MIN_SDK_VERSION="10.0"
+TVOS_MIN_SDK_VERSION="10.0"
 
 # Init optional env variables (use available variable or default to empty string)
 CURL_OPTIONS="${CURL_OPTIONS:-}"
@@ -336,9 +336,9 @@ fi
 
 # Determine number of cores for (parallel) build
 BUILD_THREADS=1
-if [ "${PARALLEL}" != "false" ]; then
-  BUILD_THREADS=$(sysctl hw.ncpu | awk '{print $2}')
-fi
+#if [ "${PARALLEL}" != "false" ]; then
+#  BUILD_THREADS=$(sysctl hw.ncpu | awk '{print $2}')
+#fi
 
 # Determine script directory
 SCRIPTDIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
@@ -512,6 +512,9 @@ if [ ${#OPENSSLCONF_ALL[@]} -gt 1 ]; then
         DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_SIMULATOR && TARGET_CPU_X86"
       ;;
       *_ios_arm64.h)
+        DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_EMBEDDED && TARGET_CPU_ARM64"
+      ;;
+	  *_ios_arm64e.h)
         DEFINE_CONDITION="TARGET_OS_IOS && TARGET_OS_EMBEDDED && TARGET_CPU_ARM64"
       ;;
       *_ios_armv7s.h)

--- a/config/20-ios-tvos-cross.conf
+++ b/config/20-ios-tvos-cross.conf
@@ -53,6 +53,16 @@
         perlasm_scheme   => "ios64",
         sys_id           => "iOS",
     },
+    
+	## Apple iOS (arm64e)
+    # Based on 10-main.conf: ios64-cross
+    "ios64-cross-arm64e" => {
+        inherit_from     => [ "darwin-common", "ios-cross-base", asm("aarch64_asm") ],
+        cflags           => add("-arch arm64e"),
+        bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
+        perlasm_scheme   => "ios64",
+        sys_id           => "iOS",
+    },
 
     ## Apple iOS (armv7s)
     # Based on 10-main.conf: ios-cross


### PR DESCRIPTION
- Support arm64e architecture
- Disable multithread compiling when using Xcode 10
- No need support iOS i386 due to architecture is too old