### PR TITLE
fixed build failure when CURRENTPATH != SCRIPTDIR

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -494,7 +494,7 @@ if [ ${#OPENSSLCONF_ALL[@]} -gt 1 ]; then
   # Prepare intermediate header file
   # This overwrites opensslconf.h that was copied from $INCLUDE_DIR
   OPENSSLCONF_INTERMEDIATE="${CURRENTPATH}/include/openssl/opensslconf.h"
-  cp "${CURRENTPATH}/include/opensslconf-template.h" "${OPENSSLCONF_INTERMEDIATE}"
+  cp "${SCRIPTDIR}/include/opensslconf-template.h" "${OPENSSLCONF_INTERMEDIATE}"
 
   # Loop all header files
   LOOPCOUNT=0


### PR DESCRIPTION
`include/opensslconf-template.h` is in the OpenSSL-`for-iPhone repo, a.k.a `$SCRIPTDIR