### PR TITLE
fix for watch os mac-m1 simulator

### DIFF
--- a/build-libssl.sh
+++ b/build-libssl.sh
@@ -194,7 +194,7 @@ finish_build_loop()
   elif [[ "${PLATFORM}" == WatchSimulator ]]; then
     LIBSSL_WATCHOSSIM+=("${TARGETDIR}/lib/libssl.a")
     LIBCRYPTO_WATCHOSSIM+=("${TARGETDIR}/lib/libcrypto.a")
-    OPENSSLCONF_SUFFIX="watchos_${ARCH}"
+    OPENSSLCONF_SUFFIX="watchos_sim_${ARCH}"
   else # Catalyst
     LIBSSL_CATALYST+=("${TARGETDIR}/lib/libssl.a")
     LIBCRYPTO_CATALYST+=("${TARGETDIR}/lib/libcrypto.a")
@@ -640,14 +640,14 @@ if [ ${#OPENSSLCONF_ALL[@]} -gt 1 ]; then
       *_watchos_i386.h)
         DEFINE_CONDITION="TARGET_OS_WATCH && TARGET_OS_SIMULATOR && TARGET_CPU_X86"
       ;;
-      *_watchos_x86_64.h)
+      *_watchos_sim_x86_64.h)
         DEFINE_CONDITION="TARGET_OS_WATCH && TARGET_OS_SIMULATOR && TARGET_CPU_X86_64"
+      ;;
+      *_watchos_sim_arm64.h)
+        DEFINE_CONDITION="TARGET_OS_WATCH && TARGET_OS_SIMULATOR && TARGET_CPU_ARM64"
       ;;
       *_watchos_armv7k.h)
         DEFINE_CONDITION="TARGET_OS_WATCH && TARGET_CPU_ARM"
-      ;;
-      *_watchos_arm64.h)
-        DEFINE_CONDITION="TARGET_OS_WATCH && TARGET_CPU_ARM64"
       ;;
       *_watchos_arm64_32.h)
         DEFINE_CONDITION="TARGET_OS_WATCH && TARGET_CPU_ARM64"


### PR DESCRIPTION
When running 
./build-libssl.sh --version=1.1.1l --verbose --targets="watchos-sim-cross-x86_64 watchos-sim-cross-arm64 watchos-cross-armv7k watchos-cross-arm64_32"
current code will generate opensslconf.h as follows:
<img width="518" alt="err_opensslconf" src="https://github.com/x2on/OpenSSL-for-iPhone/assets/46767782/7f644705-3ec8-422a-b833-9ba072438800">
so it can not tell the difference between opensslconf_watchos_arm64.h and opensslconf_watchos_arm64_32.h, and there isn't a branch for watch os mac-m1 simulator.

after my patch, it will generate opensslconf.h as follows:
<img width="1728" alt="correct_opensslconf" src="https://github.com/x2on/OpenSSL-for-iPhone/assets/46767782/1d5d3bb1-5ecb-47c1-8fe5-7a56e05deb9f">
it is clear that line 30 is for watch os mac-m1 simulator.